### PR TITLE
fix typo

### DIFF
--- a/docs/usage/scan_engine.md
+++ b/docs/usage/scan_engine.md
@@ -508,7 +508,7 @@ Number of times to retry a failed request **(default 1)**
 
 * **template (required)**
 
-Please refer to [nuclei's documentation](https://github.com/projectdiscovery/nuclei) to check which templates are supported. Nuclei may release any new templates which may not be possible to update here in the documentation, so it is adviced that you refer to [Nuclei's documentation]((https://github.com/projectdiscovery/nuclei).
+Please refer to [nuclei's documentation](https://github.com/projectdiscovery/nuclei) to check which templates are supported. Nuclei may release any new templates which may not be possible to update here in the documentation, so it is adviced that you refer to [Nuclei's documentation](https://github.com/projectdiscovery/nuclei).
 
 Some of the supported options for template are:
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16578570/135931641-2a5054f8-e943-48d2-a78a-90e1d9d96260.png)

this small typo was breaking the link